### PR TITLE
Update Lambda runtime to Node.js 22

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,6 +24,11 @@ jobs:
         with:
           ref: master
 
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
       - name: Install
         run: npm install
       
@@ -52,4 +57,11 @@ jobs:
           aws lambda update-function-code \
             --function-name music-graphql \
             --zip-file fileb://server.zip \
+            --region us-east-1
+
+      - name: Update Lambda runtime (Node.js 22)
+        run: |
+          aws lambda update-function-configuration \
+            --function-name music-graphql \
+            --runtime nodejs22.x \
             --region us-east-1


### PR DESCRIPTION
## Summary
- Pin GitHub Actions to Node.js 22 for build/package steps.
- Update the `music-graphql` Lambda runtime to `nodejs22.x` to avoid the Node.js 20 Lambda deprecation.

## Test plan
- Merge this PR (deploy runs on merge to `master`).
- In AWS Lambda console, verify `music-graphql` runtime shows **Node.js 22.x**.
- Invoke the GraphQL endpoint and confirm normal responses.

Made with [Cursor](https://cursor.com)